### PR TITLE
Fix double input in terminal by disposing previous onData listeners

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -30,6 +30,7 @@ export class ContainerManager {
   private audit: AuditLog | null = null;
   private policy: PolicyEngine | null = null;
   private activeProcessCount = 0;
+  private onDataDisposable: { dispose(): void } | null = null;
   private outputLineBuf = '';
   private outputFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private gitService: GitService | null = null;
@@ -369,7 +370,8 @@ export class ContainerManager {
 
     // Wire keystrokes directly to gitclaw stdin (no jsh in between)
     this.shellWriter = this.shellProcess.input.getWriter();
-    terminal.onData((data) => {
+    this.onDataDisposable?.dispose();
+    this.onDataDisposable = terminal.onData((data) => {
       this.shellWriter?.write(data);
       this.audit?.logStdin(data);
     });
@@ -418,7 +420,8 @@ export class ContainerManager {
     );
 
     this.shellWriter = this.shellProcess.input.getWriter();
-    terminal.onData((data) => {
+    this.onDataDisposable?.dispose();
+    this.onDataDisposable = terminal.onData((data) => {
       this.shellWriter?.write(data);
       this.audit?.logStdin(data);
     });
@@ -593,7 +596,8 @@ export class ContainerManager {
     );
 
     this.shellWriter = this.shellProcess.input.getWriter();
-    terminal.onData((data) => {
+    this.onDataDisposable?.dispose();
+    this.onDataDisposable = terminal.onData((data) => {
       this.shellWriter?.write(data);
       this.audit?.logStdin(data);
     });

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -62,8 +62,8 @@ export class TerminalManager {
   }
 
   /** Register a handler for user keystrokes (sent to shell stdin). */
-  onData(handler: (data: string) => void): void {
-    this.xterm.onData(handler);
+  onData(handler: (data: string) => void): { dispose(): void } {
+    return this.xterm.onData(handler);
   }
 
   /** Current terminal dimensions for pty resize. */


### PR DESCRIPTION
When startGitclaw/startShell/startAgent restarted (e.g. after process
exit), a new xterm onData handler was registered without removing the
previous one. Each restart stacked another listener, causing every
keystroke to be written to stdin multiple times ("hi" → "hhii").

Track the onData disposable in ContainerManager and dispose it before
each new registration.
